### PR TITLE
Add/makefile for mlton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .cm/
 libsha2sml.d
 test/sources.d
+# mlton
+libsha2sml.mlb.d
+test/sources.mlb.d
+test/sources
 # polyml
 libsha2sml.poly
 sha2test-poly.o

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,15 +1,18 @@
 
 MLTON          ?= mlton
 MLTON_FLAGS    ?= -default-ann "nonexhaustiveMatch ignore"
-ifneq ($(MLB_PATH_MAP),)
-MLTON_FLAGS    += -mlb-path-map $(MLB_PATH_MAP)
-endif
 
 SMLDOC         ?= smldoc
 
 PREFIX         ?= /usr/local/mlton
 LIBDIR         ?= lib/libsha2sml
 DOCDIR         ?= doc/libsha2sml
+
+ifneq ($(MLB_PATH_MAP),)
+MLTON_FLAGS    += -mlb-path-map $(MLB_PATH_MAP)
+else
+MLTON_FLAGS    += -mlb-path-map $(PREFIX)/mlb-path-map
+endif
 
 LIBSHA2SML_MLB      ?= libsha2sml.mlb
 LIBSHA2SML_TEST_MLB ?= test/sources.mlb

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,0 +1,110 @@
+
+MLTON          ?= mlton
+MLTON_FLAGS    ?= -default-ann "nonexhaustiveMatch ignore"
+ifneq ($(MLB_PATH_MAP),)
+MLTON_FLAGS    += -mlb-path-map $(MLB_PATH_MAP)
+endif
+
+SMLDOC         ?= smldoc
+
+PREFIX         ?= /usr/local/mlton
+LIBDIR         ?= lib/libsha2sml
+DOCDIR         ?= doc/libsha2sml
+
+LIBSHA2SML_MLB      ?= libsha2sml.mlb
+LIBSHA2SML_TEST_MLB ?= test/sources.mlb
+LIBSHA2SML_MLBS     ?= $(LIBSHA2SML_MLB)      \
+                       $(LIBSHA2SML_TEST_MLB)
+
+
+all: libsha2sml-nodoc
+
+
+.PHONY: libsha2sml-nodoc
+libsha2sml-nodoc: typecheck_sha2sml
+
+
+.PHONY: libsha2sml
+libsha2sml: libsha2sml-nodoc doc
+
+
+.PHONY: typecheck_sha2sml
+typecheck_sha2sml: $(LIBSHA2SML_MLB)
+	@echo "  [MLTON] typecheck $<"
+	@$(MLTON) $(MLTON_FLAGS) -stop tc $<
+
+
+$(LIBSHA2SML_TEST_MLB:.mlb=): %: %.mlb
+	@echo "  [MLTON] $@"
+	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
+
+
+%.mlb.d: %.mlb
+	@echo "  [GEN] $@"
+	@$(SHELL) -ec '$(MLTON) $(MLTON_FLAGS) -stop f $< \
+		| sed -e "1i$(<:.mlb=) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
+		[ -s $@ ] || rm -rf $@'
+
+
+.PHONY: test
+test: typecheck_sha2sml $(LIBSHA2SML_TEST_MLB:.mlb=)
+	$(LIBSHA2SML_TEST_MLB:.mlb=)
+
+
+ifeq ($(findstring clean,$(MAKECMDGOALS)),)
+  include $(LIBSHA2SML_MLBS:.mlb=.mlb.d)
+endif
+
+
+.PHONY: install-nodoc
+install-nodoc: libsha2sml-nodoc
+	@install -d $(PREFIX)/$(LIBDIR)
+	@$(MLTON) $(MLTON_FLAGS) -stop f $(LIBSHA2SML_MLB) | \
+	while read file; do \
+		if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
+			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/$(LIBDIR); \
+			echo -n . ; \
+		fi; \
+	done
+	@echo "Installation has been completed."
+	@echo "Please add the entry to your mlb path map file:"
+	@echo ""
+	@echo "  SHA2SML $(PREFIX)/$(LIBDIR)"
+	@echo ""
+
+
+.PHONY: install
+install: install-nodoc install-doc
+
+
+.PHONY: doc
+doc:
+	@echo "  [SMLDoc] $@"
+	@$(RM) -r doc
+	@mkdir doc
+	@$(SMLDOC) -c UTF-8 \
+		--builtinstructure=Word8 \
+		--builtinstructure=TextIO \
+		--builtinstructure=VectorSlice \
+		--hidebysig \
+		--recursive \
+		--linksource \
+		-d doc \
+		libsha2sml.cm
+
+
+.PHONY: install-doc
+install-doc: doc
+	@install -d $(PREFIX)/$(DOCDIR)
+	@cp -prT doc $(PREFIX)/$(DOCDIR)
+	@echo "================================================================"
+	@echo "Generated API Documents of Sha2SML"
+	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "================================================================"
+
+
+.PHONY: clean
+clean:
+	-$(RM) $(LIBSHA2SML_MLBS:.mlb=)
+	-$(RM) $(LIBSHA2SML_MLBS:.mlb=.mlb.d)
+	-$(RM) -r doc

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,45 +1,55 @@
 
-MLTON          ?= mlton
-MLTON_FLAGS    ?= -default-ann "nonexhaustiveMatch ignore"
+MLTON               := mlton
+MLTON_FLAGS         := -default-ann "nonexhaustiveMatch ignore"
 
-SMLDOC         ?= smldoc
-
-PREFIX         ?= /usr/local/mlton
-LIBDIR         ?= lib/libsha2sml
-DOCDIR         ?= doc/libsha2sml
-
+# path to the file `mlb-path-map`
 ifneq ($(MLB_PATH_MAP),)
-MLTON_FLAGS    += -mlb-path-map $(MLB_PATH_MAP)
-else
-MLTON_FLAGS    += -mlb-path-map $(PREFIX)/mlb-path-map
+  MLTON_FLAGS       += -mlb-path-map $(MLB_PATH_MAP)
 endif
 
-LIBSHA2SML_MLB      ?= libsha2sml.mlb
-LIBSHA2SML_TEST_MLB ?= test/sources.mlb
-LIBSHA2SML_MLBS     ?= $(LIBSHA2SML_MLB)      \
+SMLDOC              := smldoc
+
+PREFIX              := /usr/local/mlton
+LIBDIR              := lib/libsha2sml
+DOCDIR              := doc/libsha2sml
+
+LIBSHA2SML_MLB      := libsha2sml.mlb
+LIBSHA2SML_TEST_MLB := test/sources.mlb
+LIBSHA2SML_MLBS     := $(LIBSHA2SML_MLB)      \
                        $(LIBSHA2SML_TEST_MLB)
 
+DEPENDS             := $(LIBSHA2SML_MLBS:.mlb=.mlb.d)
 
-all: libsha2sml-nodoc
+TYPECHECK_DUMMY     := bin/.libsha2sml
+
+
+all: libsha2sml
 
 
 .PHONY: libsha2sml-nodoc
-libsha2sml-nodoc: typecheck_sha2sml
+libsha2sml-nodoc: $(TYPECHECK_DUMMY)
 
 
 .PHONY: libsha2sml
 libsha2sml: libsha2sml-nodoc doc
 
 
-.PHONY: typecheck_sha2sml
-typecheck_sha2sml: $(LIBSHA2SML_MLB)
-	@echo "  [MLTON] typecheck $<"
+$(TYPECHECK_DUMMY): $(LIBSHA2SML_MLB)
+	@echo "  [MLTON] typecheck: $<"
 	@$(MLTON) $(MLTON_FLAGS) -stop tc $<
+	@touch $@
 
 
 $(LIBSHA2SML_TEST_MLB:.mlb=): %: %.mlb
 	@echo "  [MLTON] $@"
 	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
+
+
+libsha2sml.mlb.d: libsha2sml.mlb
+	@echo "  [GEN] $@"
+	@$(SHELL) -ec '$(MLTON) $(MLTON_FLAGS) -stop f $< \
+		| sed -e "1i$(TYPECHECK_DUMMY) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
+		[ -s $@ ] || rm -rf $@'
 
 
 %.mlb.d: %.mlb
@@ -49,13 +59,8 @@ $(LIBSHA2SML_TEST_MLB:.mlb=): %: %.mlb
 		[ -s $@ ] || rm -rf $@'
 
 
-.PHONY: test
-test: typecheck_sha2sml $(LIBSHA2SML_TEST_MLB:.mlb=)
-	$(LIBSHA2SML_TEST_MLB:.mlb=)
-
-
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
-  include $(LIBSHA2SML_MLBS:.mlb=.mlb.d)
+  include $(DEPENDS)
 endif
 
 
@@ -77,14 +82,14 @@ install-nodoc: libsha2sml-nodoc
 
 
 .PHONY: install
-install: install-nodoc install-doc
+install: install-doc install-nodoc
 
 
 .PHONY: doc
 doc:
-	@echo "  [SMLDoc] $@"
-	@$(RM) -r doc
-	@mkdir doc
+	@echo "  [SMLDoc] $(DOCDIR)"
+	@$(RM) -r $(DOCDIR)
+	@install -d $(DOCDIR)
 	@$(SMLDOC) -c UTF-8 \
 		--builtinstructure=Word8 \
 		--builtinstructure=TextIO \
@@ -92,22 +97,28 @@ doc:
 		--hidebysig \
 		--recursive \
 		--linksource \
-		-d doc \
+		-d $(DOCDIR) \
 		libsha2sml.cm
 
 
 .PHONY: install-doc
 install-doc: doc
 	@install -d $(PREFIX)/$(DOCDIR)
-	@cp -prT doc $(PREFIX)/$(DOCDIR)
+	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
 	@echo "================================================================"
 	@echo "Generated API Documents of Sha2SML"
 	@echo "\t$(PREFIX)/$(DOCDIR)"
 	@echo "================================================================"
 
 
+.PHONY: test
+test: $(LIBSHA2SML_TEST_MLB:.mlb=)
+	$(LIBSHA2SML_TEST_MLB:.mlb=)
+
+
 .PHONY: clean
 clean:
-	-$(RM) $(LIBSHA2SML_MLBS:.mlb=)
-	-$(RM) $(LIBSHA2SML_MLBS:.mlb=.mlb.d)
-	-$(RM) -r doc
+	-$(RM) $(TYPECHECK_DUMMY)
+	-$(RM) $(DEPENDS)
+	-$(RM) -r $(DOCDIR)
+	-$(RM) $(filter-out libsha2sml,$(LIBSHA2SML_MLBS:.mlb=))

--- a/readme.rst
+++ b/readme.rst
@@ -93,12 +93,28 @@ Sha2SML allows users to loading it in place:
 MLton
 ----------------------------------------------------------------
 
-Add the path of the **Sha2SML** directory to mlb-map file, it enables MLton to use it as a SML library.
+To install Sha2SML for MLton, perform :code:`install` target.
 
 .. code-block:: sh
 
-    $ DESTDIR=/usr/lib/mlton/mlb-path-map
-    $ echo "SHA2SML /path/to/sha2sml" >> ${DESTDIR}
+    $ make install
+
+
+This target requires `SMLDoc`_ for generating documentations.
+To install without documents, perform :code:`install-nodoc`
+
+.. code-block:: sh
+
+    $ make install-nodoc
+
+
+To refer to the installed library as SHA2SML, add an entry to the mlb-path-map file as follows.
+
+.. code-block:: sh
+
+    $ PREFIX=... # default /usr/local/mlton
+    $ make install PREFIX=$(PREFIX)
+    $ echo "SHA2SML ${PREFIX}/lib/libsha2sml" >> /path/to/mlb-path-map
 
 
 Poly/ML
@@ -178,15 +194,12 @@ By executing the :code:`test` target, the unit tests will be executed and the re
 MLton
 ----------------------------------------------------------------
 
-Building the unit test project defined with the MLB.
+To run the unit tests, run the target.
 
 .. code-block:: sh
 
-    $ mlton ./test/sources.mlb
+    $ make -f Makefile.mlton test
 
-Then you will see the result of each test case.
-
-.. code-block:: sh
 
     $ ./test/sources
     .......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

--- a/readme.rst
+++ b/readme.rst
@@ -31,7 +31,7 @@ Install
 SML/NJ
 ----------------------------------------------------------------
 
-To install **Sha2SML** to your environment, you need to perform the :code:`install` target of Makefile.smlnj.
+To install **Sha2SML** to your environment, run the :code:`install` target of Makefile.smlnj.
 
 .. code-block:: sh
 
@@ -93,27 +93,34 @@ Sha2SML allows users to loading it in place:
 MLton
 ----------------------------------------------------------------
 
-To install Sha2SML for MLton, perform :code:`install` target.
+To install **Sha2SML** for MLton, run the :code:`install` target of Makefile.mlton.
 
 .. code-block:: sh
 
-    $ make install
+    $ make -f Makefile.mlton install
 
 
-This target requires `SMLDoc`_ for generating documentations.
-To install without documents, perform :code:`install-nodoc`
+Or you can specify install directory with PREFIX like below
 
 .. code-block:: sh
 
-    $ make install-nodoc
+    $ make -f Makefile.mlton install PREFIX=~/.sml/mlton
 
 
-To refer to the installed library as SHA2SML, add an entry to the mlb-path-map file as follows.
+The :code:`install` target requires `SMLDoc`_ to generates documentations.
+To install library without documentations, specify :code:`install-nodoc` target.
+
+.. code-block:: sh
+
+    $ make -f Makefile.mlton install-nodoc
+
+
+To complete the installation, add an entry to the *mlb-path-map* file as follows.
 
 .. code-block:: sh
 
     $ PREFIX=... # default /usr/local/mlton
-    $ make install PREFIX=$(PREFIX)
+    $ make install PREFIX=${PREFIX}
     $ echo "SHA2SML ${PREFIX}/lib/libsha2sml" >> /path/to/mlb-path-map
 
 
@@ -178,7 +185,7 @@ These test cases are imported from:
 SML/NJ
 ----------------------------------------------------------------
 
-By executing the :code:`test` target, the unit tests will be executed and the results will be displayed.
+To run the unit tests, run the :code:`test` target.
 
 .. code-block:: sh
 
@@ -194,7 +201,7 @@ By executing the :code:`test` target, the unit tests will be executed and the re
 MLton
 ----------------------------------------------------------------
 
-To run the unit tests, run the target.
+To run the unit tests, run the :code:`test` target.
 
 .. code-block:: sh
 


### PR DESCRIPTION
Add a Makefile for MLton.
The Makefile.mlton provides targets:

- `libsha2sml` and `libsha2sml-nodoc` (build)
- `install` and `install-nodoc`
- `doc`
- `test`
- `clean`

These targets are same to `Makefile.smlnj`.
