### PR TITLE
Improve makefile for polyml

### DIFF
--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -8,8 +8,8 @@ SMLDOC          ?= smldoc
 SHA2SML_VERSION := 0.9.0
 
 PREFIX          := /usr/local/polyml
-LIBDIR          ?= lib
-DOCDIR          ?= doc
+LIBDIR          := lib
+DOCDIR          := doc/libsha2sml
 
 SRC             := $(wildcard src/*)
 TEST_SRC        := $(wildcard test/*)
@@ -68,9 +68,9 @@ install: install-nodoc install-doc
 
 .PHONY: doc
 doc:
-	@echo "  [SMLDoc] $@"
-	@$(RM) -r doc
-	@mkdir doc
+	@echo "  [SMLDoc] $(DOCDIR)"
+	@$(RM) -r $(DOCDIR)
+	@install -d $(DOCDIR)
 	@$(SMLDOC) -c UTF-8 \
 		--builtinstructure=Word8 \
 		--builtinstructure=Word32 \
@@ -82,23 +82,23 @@ doc:
 		--hidebysig \
 		--recursive \
 		--linksource \
-		-d doc \
+		-d $(DOCDIR) \
 		libsha2sml.cm
 
 
 .PHONY: install-doc
 install-doc: doc
-	@install -d $(PREFIX)/$(DOCDIR)/libsha2sml
-	@cp -prT doc $(PREFIX)/$(DOCDIR)/libsha2sml
+	@install -d $(PREFIX)/$(DOCDIR)
+	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
 	@echo "================================================================"
 	@echo "Generated API Documents of Sha2SML"
-	@echo "\t$(PREFIX)/$(DOCDIR)/libsha2sml"
+	@echo "\t$(PREFIX)/$(DOCDIR)"
 	@echo "================================================================"
 
 
 .PHONY: clean
 clean:
 	-$(RM) $(TARGET)
-	-$(RM) -r doc
+	-$(RM) -r $(DOCDIR)
 	-$(RM) sha2test-poly
 	-$(RM) sha2test-poly.o

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -13,7 +13,11 @@ DOCDIR          := doc/libsha2sml
 
 SRC             := $(wildcard src/*)
 TEST_SRC        := $(wildcard test/*)
-LIBSMLUNIT      := $(PREFIX)/lib/SMLUnit/libsmlunit.poly
+
+# Path to the directory which contains the binary module of [SMLUnit] like:
+# > make -f Makefile.polyml POLYML_LIBDIR=~/.sml/polyml/5.8.1/lib
+POLYML_LIBDIR   := SPECIFY_THE_POLYML_LIBDIR
+LIBSMLUNIT      := $(POLYML_LIBDIR)/smlunit-lib/smlunit-lib.poly
 
 TARGET          := libsha2sml-$(SHA2SML_VERSION).poly
 

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -18,7 +18,7 @@ LIBSMLUNIT      := $(PREFIX)/lib/SMLUnit/libsmlunit.poly
 TARGET          := libsha2sml-$(SHA2SML_VERSION).poly
 
 
-all: libsha2sml-nodoc
+all: libsha2sml
 
 
 .PHONY: libsha2sml-nodoc

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -3,15 +3,30 @@ POLYML          ?= poly
 POLYMLC         ?= polyc
 POLYMLFLAGS     ?= -q --error-exit --eval 'PolyML.suffixes := ".sig"::(!PolyML.suffixes)'
 
+SMLDOC          ?= smldoc
+
 SHA2SML_VERSION := 0.9.0
+
+PREFIX          := /usr/local/polyml
+LIBDIR          ?= lib
+DOCDIR          ?= doc
 
 SRC             := $(wildcard src/*)
 TEST_SRC        := $(wildcard test/*)
+LIBSMLUNIT      := $(PREFIX)/$(LIBDIR)/SMLUnit/libsmlunit.poly
 
 TARGET          := libsha2sml-$(SHA2SML_VERSION).poly
 
 
-all: $(TARGET) test
+all: libsha2sml-nodoc
+
+
+.PHONY: libsha2sml-nodoc
+libsha2sml-nodoc: $(TARGET)
+
+
+.PHONY: libsha2sml
+libsha2sml: libsha2sml-nodoc doc
 
 
 $(TARGET): $(SRC)
@@ -19,21 +34,16 @@ $(TARGET): $(SRC)
 	@echo "" | $(POLYML) $(POLYMLFLAGS) \
 	    --eval 'PolyML.make "src"' \
 		--use export.sml \
-		--eval 'PolyML.SaveState.saveModule ("$(TARGET)", Sha2SML)'
+		--eval 'PolyML.SaveState.saveModule ("$(TARGET)", Sha2SML)' >/dev/null
 
 
-sha2test-poly.o: $(TARGET) $(TEST_SRC)
-	@echo "LIBSMLUNIT: $(LIBSMLUNIT)"
-ifeq ($(LIBSMLUNIT),)
-	@echo "*** Please set LIBSMLUNIT to path to libsmlunit.poly ***" >&2
-	@exit 1
-endif
+sha2test-poly.o: $(TARGET) $(TEST_SRC) $(LIBSMLUNIT)
 	@echo "  [POLYML] $@"
 	@echo "" | $(POLYML) $(POLYMLFLAGS) \
 	    --eval 'PolyML.loadModule "$(LIBSMLUNIT)"' \
 	    --eval 'PolyML.loadModule "./$(TARGET)"' \
 	    --eval 'PolyML.make "test"' \
-		--eval 'PolyML.export ("$@", Sha2Test.main'"'"')'
+		--eval 'PolyML.export ("$@", Sha2Test.main'"'"')' >/dev/null
 
 
 sha2test-poly: sha2test-poly.o
@@ -41,19 +51,54 @@ sha2test-poly: sha2test-poly.o
 	@$(POLYMLC) -o $@ $^
 
 
-.PHONY: install
-install: $(TARGET)
-	@install -d $(PREFIX)/polyml/lib
-	install -D -m 644 -t $(PREFIX)/polyml/lib $(TARGET)
-
-
 .PHONY: test
 test: sha2test-poly
 	./sha2test-poly
 
 
+.PHONY: install-nodoc
+install-nodoc: libsha2sml-nodoc
+	@install -d $(PREFIX)/$(LIBDIR)/libsha2sml
+	@install -D -m 644 -t $(PREFIX)/$(LIBDIR)/libsha2sml $(TARGET)
+
+
+.PHONY: install
+install: install-nodoc install-doc
+
+
+.PHONY: doc
+doc:
+	@echo "  [SMLDoc] $@"
+	@$(RM) -r doc
+	@mkdir doc
+	@$(SMLDOC) -c UTF-8 \
+		--builtinstructure=Word8 \
+		--builtinstructure=Word32 \
+		--builtinstructure=Word64 \
+		--builtinstructure=BinIO \
+		--builtinstructure=TextIO \
+		--builtinstructure=VectorSlice \
+		--builtinstructure=StringCvt \
+		--hidebysig \
+		--recursive \
+		--linksource \
+		-d doc \
+		libsha2sml.cm
+
+
+.PHONY: install-doc
+install-doc: doc
+	@install -d $(PREFIX)/$(DOCDIR)/libsha2sml
+	@cp -prT doc $(PREFIX)/$(DOCDIR)/libsha2sml
+	@echo "================================================================"
+	@echo "Generated API Documents of Sha2SML"
+	@echo "\t$(PREFIX)/$(DOCDIR)/libsha2sml"
+	@echo "================================================================"
+
+
 .PHONY: clean
 clean:
 	-$(RM) $(TARGET)
+	-$(RM) -r doc
 	-$(RM) sha2test-poly
 	-$(RM) sha2test-poly.o

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -8,12 +8,12 @@ SMLDOC          ?= smldoc
 SHA2SML_VERSION := 0.9.0
 
 PREFIX          := /usr/local/polyml
-LIBDIR          := lib
+LIBDIR          := lib/libsha2sml
 DOCDIR          := doc/libsha2sml
 
 SRC             := $(wildcard src/*)
 TEST_SRC        := $(wildcard test/*)
-LIBSMLUNIT      := $(PREFIX)/$(LIBDIR)/SMLUnit/libsmlunit.poly
+LIBSMLUNIT      := $(PREFIX)/lib/SMLUnit/libsmlunit.poly
 
 TARGET          := libsha2sml-$(SHA2SML_VERSION).poly
 
@@ -58,12 +58,15 @@ test: sha2test-poly
 
 .PHONY: install-nodoc
 install-nodoc: libsha2sml-nodoc
-	@install -d $(PREFIX)/$(LIBDIR)/libsha2sml
-	@install -D -m 644 -t $(PREFIX)/$(LIBDIR)/libsha2sml $(TARGET)
+	@install -D -m 644 -t $(PREFIX)/$(LIBDIR) $(TARGET)
+	@echo "================================================================"
+	@echo "libsha2sml has been installed to:"
+	@echo "\t$(PREFIX)/$(LIBDIR)/$(TARGET)"
+	@echo "================================================================"
 
 
 .PHONY: install
-install: install-nodoc install-doc
+install: install-doc install-nodoc
 
 
 .PHONY: doc

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -25,7 +25,7 @@ DEPENDS         := libsha2sml.d test/sources.d
 TEST_TARGET     ?= bin/Sha2Test.$(HEAP_SUFFIX)
 
 
-all: libsha2sml-nodoc
+all: libsha2sml
 
 
 .PHONY: libsha2sml-nodoc

--- a/readme.rst
+++ b/readme.rst
@@ -127,27 +127,26 @@ To complete the installation, add an entry to the *mlb-path-map* file as follows
 Poly/ML
 ----------------------------------------------------------------
 
-Compile the module with default target.
-
-.. code-block:: sh
-
-    $ make -f Makefile.polyml
-
-
-The default target generates `libsha2sml-x.y.z.poly` in this directory.
-To install this library, use `install` target:
+To build this library for Poly/ML, run the target :code:`libsha2sml` of Makefile.polyml.
 
 .. code-block:: sh
 
     $ make -f Makefile.polyml install
 
 
-To change the installation directory, specify `PREFIX` variable like:
+Or you can specify install directory with PREFIX like below
 
 .. code-block:: sh
 
-    $ make -f Makefile.polyml PREFIX=~/.sml install
+    $ make -f Makefile.polyml install PREFIX=~/.sml/polyml
 
+
+The :code:`install` target requires `SMLDoc`_ to generates documentations.
+To install library without documentations, specify :code:`install-nodoc` target.
+
+.. code-block:: sh
+
+    $ make -f Makefile.polyml install-nodoc
 
 
 Load to Interactive Environment
@@ -167,6 +166,15 @@ Sha2SML allows users to loading it in place:
     val it = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855":
       string
 
+
+Doc
+================================================================
+
+To generates documentations of Sha2SML, run the `doc` target.
+
+.. code-block:: sh
+
+    $ make -f Makefile.(smlnj|mlton|polyml) doc
 
 
 Test
@@ -222,7 +230,7 @@ Building and executing the unit test project with Make.
 
 .. code-block:: sh
 
-    $ export LIBSMLUNIT=~/path/to/libsmlunit.poly
+    $ export POLYML_LIBDIR=/path/to/lib
     $ make -f Makefile.polyml test
     Making test
     Making Sha2Test


### PR DESCRIPTION
Improve `Makefile.polyml`.

Organize targets to be the same as smlnj.

- `libsha2sml`, `libsha2sml-nodoc`
  Build the library.
- `doc`
  Generate documentations use SMLDoc.
- `install`, `install-nodoc`
  Install library (to the path to $PREFIX)
- `test`
  Execute unit test.
 

